### PR TITLE
updated changelog to remove version tag for using ruby 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 ## HEAD:
 
-## v0.8.0 (08/26/2013):
-
-* Updated to use Ruby 2.0.0
-
-##
-
 * Fixed issue 176 where multiple deploys did not exit if first deploy failed
 
 ## v0.7.5 (07/02/13):


### PR DESCRIPTION
Version isnt getting bumped for using Ruby 2.0.0
