### PR TITLE
Locking to excon 0.25.3.

### DIFF
--- a/lib/simple_deploy/version.rb
+++ b/lib/simple_deploy/version.rb
@@ -1,3 +1,3 @@
 module SimpleDeploy
-  VERSION = "0.7.6.beta.5"
+  VERSION = "0.7.6.beta.6"
 end

--- a/simple_deploy.gemspec
+++ b/simple_deploy.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "esbit", "~> 0.0.4"
   s.add_runtime_dependency "trollop", "= 2.0"
   s.add_runtime_dependency "fog", "= 1.15.0"
+  s.add_runtime_dependency "excon", "= 0.25.3"
 end


### PR DESCRIPTION
0.25.3 was stable for all of august.  I think its the best to tie to for fog 1.15.  
