### PR TITLE
Fix pty option setting in execute command 

### DIFF
--- a/lib/simple_deploy/stack/ssh.rb
+++ b/lib/simple_deploy/stack/ssh.rb
@@ -58,6 +58,7 @@ module SimpleDeploy
 
         @logger.info "Setting command: '#{command}'."
         if sudo
+          @task.variables[:default_run_options] = {:pty => true}
           @task.load :string => "task :execute do
           sudo '#{command}'
           end"


### PR DESCRIPTION
This is a fix for using sudo in execute command. Otherwise you may get "sorry, you must have a tty to run sudo" error.
