### PR TITLE
Updated to include pinned fog-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD
 
+* Pinning to fog-core 1.21.1
+
 ## v0.9.0 (04/24/14):
 
 * Adding support for pty to execute

--- a/lib/simple_deploy/version.rb
+++ b/lib/simple_deploy/version.rb
@@ -1,3 +1,3 @@
 module SimpleDeploy
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end

--- a/simple_deploy.gemspec
+++ b/simple_deploy.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "esbit", "~> 0.0.4"
   s.add_runtime_dependency "trollop", "= 2.0"
   s.add_runtime_dependency "fog", "= 1.21.0"
+  s.add_runtime_dependency "fog-core", "= 1.21.1"
   s.add_runtime_dependency "excon", "= 0.32.0"
   s.add_runtime_dependency "unf", "= 0.1.3"
   s.add_runtime_dependency "unf_ext", "= 0.0.6"


### PR DESCRIPTION
fog split into fog and fog-core which is breaking our pin to excon.  We are pinning to fog-core 1.21.1.
