### PR TITLE
only try to read from env when it is desired

### DIFF
--- a/lib/simple_deploy/cli/shared.rb
+++ b/lib/simple_deploy/cli/shared.rb
@@ -40,7 +40,7 @@ module SimpleDeploy
           end
         end
 
-        validate_credential_env_vars if provided.has_key?(:read_from_env)
+        validate_credential_env_vars if provided[:read_from_env]
 
         if provided[:environment]
           unless SimpleDeploy.environments.keys.include? provided[:environment]


### PR DESCRIPTION
fixes an issue in which specifying `-e xxx` was still trying to read env vars
